### PR TITLE
fix: live status block overflow issues

### DIFF
--- a/thingconnect.pulse.client/src/components/status/StatusTable.tsx
+++ b/thingconnect.pulse.client/src/components/status/StatusTable.tsx
@@ -51,7 +51,7 @@ export function StatusTable({ items, isLoading }: StatusTableProps) {
 
     void navigate(`/endpoints/${id}`);
   };
-  console.log('isLoading in StatusTable:', items);
+
   return (
     <Box borderRadius='md' overflow='hidden'>
       <Table.Root size='md' borderWidth={0} width='full'>


### PR DESCRIPTION
## Summary
- Fixed overflow issues in TrendBlocks component with CSS Grid layout implementation
- Implemented fixed-width container (252px total) with 20 blocks of 12px each and 4px gaps
- Added proper overflow containment and box-sizing controls
- Removed debug console.log from StatusTable component

## Changes Made
- **TrendBlocks.tsx**: Complete refactor using CSS Grid instead of HStack
  - Fixed-width layout prevents overflow in dashboard cards
  - Improved animation performance with `will-change` transforms
  - Better memory management with proper cleanup timers
  - Added debug logging for data flow monitoring
- **StatusTable.tsx**: Removed debug console.log statement

## Test Plan
- [ ] Verify TrendBlocks no longer overflow their container in dashboard view
- [ ] Confirm animations (heartbeat, slide-left, slide-in) work smoothly
- [ ] Test with varying amounts of data (0 to 20+ points)
- [ ] Verify responsive behavior across different screen sizes
- [ ] Check dark mode styling consistency

🤖 Generated with [Claude Code](https://claude.ai/code)